### PR TITLE
Initialize optional auth inputs in config flow

### DIFF
--- a/custom_components/nest_protect/config_flow.py
+++ b/custom_components/nest_protect/config_flow.py
@@ -74,9 +74,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         session = async_create_clientsession(self.hass)
         client = NestClient(session=session, environment=NEST_ENVIRONMENTS[environment])
 
-        issue_token = user_input.get(CONF_ISSUE_TOKEN)
-        cookies = user_input.get(CONF_COOKIES)
-        refresh_token = user_input.get(CONF_REFRESH_TOKEN)
+        issue_token = None
+        cookies = None
+        refresh_token = None
+
+        if CONF_ISSUE_TOKEN in user_input:
+            issue_token = user_input[CONF_ISSUE_TOKEN]
+        if CONF_COOKIES in user_input:
+            cookies = user_input[CONF_COOKIES]
+        if CONF_REFRESH_TOKEN in user_input:
+            refresh_token = user_input[CONF_REFRESH_TOKEN]
 
         if issue_token and cookies:
             auth = await client.get_access_token_from_cookies(issue_token, cookies)


### PR DESCRIPTION
### Motivation
- Initialize `issue_token`, `cookies`, and `refresh_token` in `async_validate_input` to avoid `UnboundLocalError` when selecting the authentication method.

### Description
- In `custom_components/nest_protect/config_flow.py` the variables `issue_token`, `cookies`, and `refresh_token` are initialized to `None` and are assigned from `user_input` only when the corresponding `CONF_...` key is present, preserving the existing auth selection (`if issue_token and cookies` / `elif refresh_token`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818617dd04832a8b19f04351d4f369)