### PR TITLE
Timezone-aware expiry check for NestResponse.is_expired

### DIFF
--- a/custom_components/nest_protect/pynest/models.py
+++ b/custom_components/nest_protect/pynest/models.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import datetime
+import logging
 from typing import Any
 
 from .enums import BucketType
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -57,14 +60,19 @@ class NestResponse:
     def is_expired(self):
         """Check if session is expired."""
         # Tue, 01-Mar-2022 23:15:55 GMT
-        expiry_date = datetime.datetime.strptime(
-            self.expires_in, "%a, %d-%b-%Y %H:%M:%S %Z"
-        )
-
-        if expiry_date <= datetime.datetime.now():
+        try:
+            expiry_date = datetime.datetime.strptime(
+                self.expires_in, "%a, %d-%b-%Y %H:%M:%S %Z"
+            ).replace(tzinfo=datetime.timezone.utc)
+        except (ValueError, TypeError) as exc:
+            _LOGGER.warning(
+                "Failed to parse session expiry date: %s",
+                self.expires_in,
+                exc_info=exc,
+            )
             return True
 
-        return False
+        return expiry_date <= datetime.datetime.now(datetime.timezone.utc)
 
 
 @dataclass


### PR DESCRIPTION
### Motivation
- Ensure session expiry handling is timezone-aware and robust to malformed expiry strings to avoid incorrect "not expired" results.

### Description
- Added module logger and defensive parsing for `expires_in` in `NestResponse.is_expired` using `datetime.datetime.strptime(...).replace(tzinfo=datetime.timezone.utc)`.
- On `ValueError` or `TypeError` during parsing the code now logs a warning and returns `True` to treat the session as expired.
- The expiry comparison now uses `datetime.datetime.now(datetime.timezone.utc)` and the function returns the boolean comparison result.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981869cf3d8832a99308b85eae8ac7a)