### PR TITLE
Add Playwright cookie wizard helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ Copy the `custom_components/nest_protect` to your custom_components folder and r
 
 (adapted from [homebridge-nest documentation](https://github.com/chrisjshull/homebridge-nest))
 
+### Option A: Playwright cookie wizard (recommended)
+
+The helper script in `scripts/nest_protect_cookie_wizard.py` launches a local browser with Playwright, guides you through Google login, and extracts the required values from network requests. The script runs entirely on your machine and does not send credentials to external services.
+
+**Prerequisites**
+
+- Python 3.10+
+- Playwright installed: `pip install playwright`
+- Playwright browser binaries installed: `playwright install chromium`
+
+**Run**
+
+```
+./scripts/nest_protect_cookie_wizard.py
+```
+
+**Limitations**
+
+- Google 2FA prompts must be completed in the browser window.
+- You may see Google consent screens depending on your account.
+- Google anti-automation protections can occasionally block or slow the flow; retry in a fresh session if needed.
+
+### Option B: Manual browser steps
+
 The values of "issue_token" and "cookies" are specific to your Google Account. To get them, follow these steps (only needs to be done once, as long as you stay logged into your Google Account).
 
 1. Open a Chrome/Edge browser tab in Incognito Mode.

--- a/scripts/nest_protect_cookie_wizard.py
+++ b/scripts/nest_protect_cookie_wizard.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Capture Nest Protect issue token and cookies with Playwright."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from playwright.sync_api import sync_playwright
+
+
+@dataclass
+class CaptureResult:
+    issue_token_url: Optional[str] = None
+    oauth_cookie: Optional[str] = None
+
+
+NEST_LOGIN_URL = "https://home.nest.com"
+
+
+def print_intro() -> None:
+    print("Nest Protect Cookie Wizard")
+    print("---------------------------")
+    print("This helper launches a local browser using Playwright.")
+    print("No credentials are sent to any external service by this script.")
+    print("Log in using the browser window that opens.")
+    print("When you are done, return here and press Enter to collect values.")
+    print("")
+
+
+def print_status(result: CaptureResult) -> None:
+    issue_status = "found" if result.issue_token_url else "missing"
+    cookie_status = "found" if result.oauth_cookie else "missing"
+    print(f"Current status: issue_token={issue_status}, cookies={cookie_status}")
+
+
+def print_copy_ready(result: CaptureResult) -> None:
+    print("\nCopy-ready values:")
+    print("-------------------")
+    print(f"issue_token: {result.issue_token_url}")
+    print(f"cookies: {result.oauth_cookie}")
+    print("\nJSON snippet:")
+    print("{")
+    print(f"  \"issue_token\": \"{result.issue_token_url}\",")
+    print(f"  \"cookies\": \"{result.oauth_cookie}\"")
+    print("}")
+
+
+def run_wizard() -> None:
+    result = CaptureResult()
+
+    def handle_request(request) -> None:
+        url = request.url
+        if "issueToken" in url and not result.issue_token_url:
+            result.issue_token_url = url
+        if "oauth2/iframe" in url:
+            cookie_header = request.headers.get("cookie")
+            if cookie_header:
+                result.oauth_cookie = cookie_header
+
+    print_intro()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=False)
+        context = browser.new_context()
+        page = context.new_page()
+        page.on("request", handle_request)
+        page.goto(NEST_LOGIN_URL, wait_until="domcontentloaded")
+
+        while True:
+            user_input = input("Press Enter once login is complete (or type 'q' to quit): ")
+            if user_input.strip().lower() == "q":
+                break
+            print_status(result)
+            if result.issue_token_url and result.oauth_cookie:
+                print_copy_ready(result)
+                break
+            print("Still waiting on both values. You can continue in the browser window.")
+
+        context.close()
+        browser.close()
+
+
+if __name__ == "__main__":
+    run_wizard()


### PR DESCRIPTION
### Motivation

- Retrieving the Nest `issue_token` and `cookies` via browser DevTools is error prone and hard to follow for many users. 
- Provide a local, reproducible helper that launches a real browser and captures the required network artifacts without sending credentials to external services. 
- Document prerequisites and limitations so users know how to run the helper and what to expect (2FA, consent screens, anti‑automation behavior).

### Description

- Add `scripts/nest_protect_cookie_wizard.py`, a Playwright-based CLI helper that launches Chromium, listens to network requests, captures the `issueToken` request URL and the `oauth2/iframe` cookie header, and prints copy-ready values and a JSON snippet.
- The script uses `sync_playwright` and registers a `handle_request()` callback to extract the `issueToken` URL and the cookie header, and exposes a minimal `run_wizard()` entry point to drive the flow.
- Update `README.md` under the "Retrieving `issue_token` and `cookies`" section with a new "Option A: Playwright cookie wizard (recommended)" entry that documents prerequisites (`pip install playwright`, `playwright install chromium`), usage (`./scripts/nest_protect_cookie_wizard.py`), and limitations (2FA, consent screens, Google anti‑automation).

### Testing

- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818ec7efac832a8526c375087a32a5)