### PR TITLE
Normalize and clarify issueToken/cookie input in Nest Protect config flow

### DIFF
--- a/custom_components/nest_protect/config_flow.py
+++ b/custom_components/nest_protect/config_flow.py
@@ -36,6 +36,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     _default_account_type: Environment = Environment.PRODUCTION
 
     @staticmethod
+    def _normalize_issue_token(issue_token: str) -> str:
+        """Normalize issue token input for validation."""
+        return issue_token.strip()
+
+    @staticmethod
+    def _normalize_cookies(cookies: str) -> str:
+        """Normalize cookie header input for validation."""
+        lines = (line.strip() for line in cookies.splitlines())
+        compact = " ".join(line for line in lines if line)
+        return " ".join(compact.split())
+
+    @staticmethod
     def _validate_issue_token(issue_token: str) -> bool:
         """Validate issue token format.
 
@@ -144,10 +156,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input:
             user_input[CONF_ACCOUNT_TYPE] = self._default_account_type
-            issue_token = user_input.get(CONF_ISSUE_TOKEN, "").strip()
-            cookies = user_input.get(CONF_COOKIES, "").strip()
-            # Store stripped values back so downstream validation and API calls
-            # use the normalized credentials
+            issue_token = self._normalize_issue_token(
+                user_input.get(CONF_ISSUE_TOKEN, "")
+            )
+            cookies = self._normalize_cookies(user_input.get(CONF_COOKIES, ""))
+            # Store normalized values back so downstream validation and API calls
+            # use consistent credentials.
             user_input[CONF_ISSUE_TOKEN] = issue_token
             user_input[CONF_COOKIES] = cookies
 

--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -15,16 +15,16 @@
           "cookies": "Cookies"
         },
         "data_description": {
-          "issue_token": "Full URL starting with https://accounts.google.com/o/oauth2/iframerpc?action=issueToken...",
-          "cookies": "Complete cookie string from the oauth2/iframe request headers"
+          "issue_token": "Paste the full Request URL from the issueToken network call, including all query parameters.",
+          "cookies": "Paste the full Cookie header value from the oauth2/iframe request (include every key=value pair, even if it wraps onto multiple lines)."
         }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_issue_token": "Invalid issue token URL. Must start with https://accounts.google.com/ and contain the issueToken action.",
-      "invalid_cookies": "Invalid cookies format. Ensure you copied the complete cookie header from the oauth2/iframe request.",
+      "invalid_issue_token": "Invalid issue token URL. Paste the full Request URL from the issueToken call, including query parameters.",
+      "invalid_cookies": "Invalid cookie header. Paste the entire Cookie header from the oauth2/iframe request with all key=value pairs.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {


### PR DESCRIPTION
### Motivation
- Reduce user errors when pasting credentials by trimming and normalizing the pasted `issueToken` URL and multi-line `Cookie` headers before validation. 
- Make the config flow helper text and validation errors explicit about pasting the full Request URL (including query params) and the complete Cookie header so users know exactly what to copy.

### Description
- Added normalization helpers `._normalize_issue_token` and `._normalize_cookies` to `custom_components/nest_protect/config_flow.py` to trim whitespace and collapse multi-line cookie headers into a single compact string. 
- Apply normalization in `async_step_account_link` so `user_input[CONF_ISSUE_TOKEN]` and `user_input[CONF_COOKIES]` are stored normalized before validation and API calls. 
- Updated `custom_components/nest_protect/strings.json` to clarify the instructions shown in the UI and to improve the `invalid_issue_token` and `invalid_cookies` error messages. 
- Minor comment wording adjusted to reflect normalization semantics in `config_flow.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818f942e1c832a807bb581863b908c)