### PR TITLE
Add auth method selection to config flow

### DIFF
--- a/custom_components/nest_protect/config_flow.py
+++ b/custom_components/nest_protect/config_flow.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_ACCOUNT_TYPE,
     CONF_ACCESS_TOKEN,
     CONF_ACCESS_TOKEN_EXPIRES_AT,
+    CONF_AUTH_METHOD,
     CONF_COOKIES,
     CONF_ISSUE_TOKEN,
     CONF_REFRESH_TOKEN,
@@ -34,6 +35,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _config_entry: ConfigEntry | None = None
     _default_account_type: Environment = Environment.PRODUCTION
+    _auth_method: str = "wizard"
 
     @staticmethod
     def _normalize_issue_token(issue_token: str) -> str:
@@ -127,11 +129,44 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
+        """Handle the initial step."""
+        return await self.async_step_auth_method(user_input)
+
+    async def async_step_auth_method(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
 
         if user_input:
+            self._auth_method = user_input[CONF_AUTH_METHOD]
+            return await self.async_step_account_type()
+
+        return self.async_show_form(
+            step_id="auth_method",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_AUTH_METHOD, default=self._auth_method): vol.In(
+                        {
+                            "wizard": "Wizard (recommended)",
+                            "manual": "Manual",
+                        }
+                    )
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_account_type(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle account type selection."""
+        errors = {}
+
+        if user_input:
             self._default_account_type = user_input[CONF_ACCOUNT_TYPE]
+            if self._auth_method == "wizard":
+                return await self.async_step_auth_method_wizard()
             return await self.async_step_account_link()
 
         return self.async_show_form(
@@ -146,6 +181,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+    async def async_step_auth_method_wizard(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the wizard instructions step."""
+        if user_input is not None:
+            return await self.async_step_account_link()
+
+        return self.async_show_form(
+            step_id="auth_method_wizard",
+            data_schema=vol.Schema({}),
         )
 
     async def async_step_account_link(

--- a/custom_components/nest_protect/const.py
+++ b/custom_components/nest_protect/const.py
@@ -13,6 +13,7 @@ DOMAIN: Final = "nest_protect"
 ATTRIBUTION: Final = "Data provided by Google"
 
 CONF_ACCOUNT_TYPE: Final = "account_type"
+CONF_AUTH_METHOD: Final = "auth_method"
 CONF_REFRESH_TOKEN: Final = "refresh_token"
 CONF_ISSUE_TOKEN: Final = "issue_token"
 CONF_COOKIES: Final = "cookies"

--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -1,6 +1,17 @@
 {
   "config": {
     "step": {
+      "auth_method": {
+        "title": "Choose Authentication Help",
+        "description": "For the wizard flow, run `scripts/nest_protect_cookie_wizard.py`, complete the prompts, and then return here to paste the resulting `issue_token` and `cookies` values.",
+        "data": {
+          "auth_method": "Authentication help"
+        }
+      },
+      "auth_method_wizard": {
+        "title": "Run the Cookie Wizard",
+        "description": "Open a terminal and run `scripts/nest_protect_cookie_wizard.py`. When the script finishes, click **Continue** to paste the `issue_token` and `cookies` values."
+      },
       "user": {
         "description": "Select your Account Type. Most users will need to select Google Account. Field Test is only available for selected testers in the Google Field Test program.",
         "data": {


### PR DESCRIPTION
### Motivation
- Guide users through an optional cookie-wizard helper before asking for credentials so the setup flow can recommend the easiest path.
- Provide a choice between a recommended `Wizard (recommended)` flow and a `Manual` flow and route the wizard choice into a description-only guidance step.

### Description
- Add a new constant `CONF_AUTH_METHOD` and default `_auth_method` set to `"wizard"` in `const.py` and `config_flow.py` to track the chosen auth method.
- Change the initial step so `async_step_user` now routes to a new `async_step_auth_method` which presents a choice between `wizard` and `manual` and stores the selection.
- Add `async_step_account_type` to collect the `CONF_ACCOUNT_TYPE` and route to `async_step_auth_method_wizard` when the wizard was chosen, otherwise continue to `account_link` as before.
- Add a description-only `auth_method_wizard` step (no input) that shows instructions and continues to `account_link` when the user presses Continue, and add localized strings in `strings.json` (`config.step.auth_method` and `config.step.auth_method_wizard`) that instruct running `scripts/nest_protect_cookie_wizard.py` and then pasting `issue_token` + `cookies`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822ca8e000832a9351b3835542dc33)