### PR TITLE
Fix Nest Protect SyntaxError and typing; mark iot_class as cloud_push

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -51,7 +51,7 @@ class HomeAssistantNestProtectData:
     """Nest Protect data stored in the Home Assistant data object."""
 
     devices: dict[str, Bucket]
-    areas: list[str, str]
+    areas: dict[str, str]
     client: NestClient
     subscription_task: asyncio.Task | None = None
 

--- a/custom_components/nest_protect/manifest.json
+++ b/custom_components/nest_protect/manifest.json
@@ -9,7 +9,7 @@
     }
   ],
   "documentation": "https://github.com/imicknl/ha-nest-protect",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/imicknl/ha-nest-protect/issues",
   "requirements": [],
   "version": "0.4.2"

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -157,7 +157,7 @@ class NestClient:
                 # Cookie method
                 if result["error"] == "USER_LOGGED_OUT":
                     raise BadCredentialsException(
-                        f"{result["error"]} - {result["detail"]}"
+                        f"{result['error']} - {result['detail']}"
                     )
 
                 raise Exception(result["error"])


### PR DESCRIPTION
### Motivation
- A malformed f-string in the cookie auth path caused a SyntaxError that prevented the integration from importing. 
- The `areas` field in the runtime dataclass is used as a mapping but was annotated as a list, causing a typing mismatch. 
- The integration uses a subscription endpoint for real-time updates, so `iot_class` should reflect push behavior.

### Description
- Fixed invalid f-string quoting in `custom_components/nest_protect/pynest/client.py` by replacing `f"{result["error"]} - {result["detail"]}"` with `f"{result['error']} - {result['detail']}"` to eliminate the SyntaxError. 
- Updated the dataclass annotation in `custom_components/nest_protect/__init__.py` from `areas: list[str, str]` to `areas: dict[str, str]` to match runtime usage. 
- Adjusted `iot_class` in `custom_components/nest_protect/manifest.json` from `cloud_polling` to `cloud_push` because the integration subscribes for updates via `subscribe_for_data`.
- Files modified: `custom_components/nest_protect/pynest/client.py`, `custom_components/nest_protect/__init__.py`, `custom_components/nest_protect/manifest.json`.

### Testing
- Ran `python -m compileall custom_components` and compilation completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698785191a04832ab1db29a3bdeab81d)